### PR TITLE
nio_run -> niod

### DIFF
--- a/container-run.sh
+++ b/container-run.sh
@@ -6,4 +6,4 @@ cd /nio/project
 find blocks -name requirements.txt -maxdepth 2 | xargs -I {} pip install -r {}
 
 # Run nio
-exec nio_run -r /nio/project
+exec niod -r /nio/project


### PR DESCRIPTION
As of 01/04/2018 new installations of nio will be run with `niod` instead of `nio_run`